### PR TITLE
Add Barline to the extras for each Measure.

### DIFF
--- a/musicdiff/annotation.py
+++ b/musicdiff/annotation.py
@@ -323,7 +323,7 @@ class AnnVoice:
 
 
 class AnnMeasure:
-    def __init__(self, measure, score):
+    def __init__(self, measure, score, spannerBundle):
         """
         Extend music21 Measure with some precomputed, easily compared information about it.
 
@@ -346,7 +346,7 @@ class AnnMeasure:
         self.n_of_voices = len(self.voices_list)
 
         self.extras_list = []
-        for extra in M21Utils.get_extras(measure, score.spannerBundle):
+        for extra in M21Utils.get_extras(measure, spannerBundle):
             self.extras_list.append(AnnExtra(extra, measure, score))
 
         # For correct comparison, sort the extras_list, so that any list slices
@@ -400,7 +400,7 @@ class AnnMeasure:
 
 
 class AnnPart:
-    def __init__(self, part, score):
+    def __init__(self, part, score, spannerBundle):
         """
         Extend music21 Part/PartStaff with some precomputed, easily compared information about it.
 
@@ -410,7 +410,7 @@ class AnnPart:
         self.part = part.id
         self.bar_list = []
         for measure in part.getElementsByClass("Measure"):
-            ann_bar = AnnMeasure(measure, score)  # create the bar objects
+            ann_bar = AnnMeasure(measure, score, spannerBundle)  # create the bar objects
             if ann_bar.n_of_voices > 0:
                 self.bar_list.append(ann_bar)
         self.n_of_bars = len(self.bar_list)
@@ -465,9 +465,10 @@ class AnnScore:
         """
         self.score = score.id
         self.part_list = []
+        spannerBundle = score.spannerBundle
         for part in score.parts.stream():
             # create and add the AnnPart object to part_list
-            ann_part = AnnPart(part, score)
+            ann_part = AnnPart(part, score, spannerBundle)
             if ann_part.n_of_bars > 0:
                 self.part_list.append(ann_part)
         self.n_of_parts = len(self.part_list)

--- a/musicdiff/m21utils.py
+++ b/musicdiff/m21utils.py
@@ -396,7 +396,6 @@ class M21Utils:
         # like Clefs, TextExpressions, and Dynamics...
         output: List[m21.base.Music21Object] = list(measure.recurse().getElementsNotOfClass((m21.note.GeneralNote,
                                                         m21.stream.Stream,
-                                                        m21.bar.Barline,
                                                         m21.layout.LayoutBase )))
 
         # we must add any Crescendo/Diminuendo spanners that start on GeneralNotes in this measure
@@ -477,6 +476,28 @@ class M21Utils:
         # pylint: enable=protected-access
 
     @staticmethod
+    def barline_to_string(barline: m21.bar.Barline) -> str:
+        # for all Barlines: type, pause
+        # for Repeat Barlines: direction, times
+        pauseStr: str = ''
+        if barline.pause is not None:
+            if isinstance(barline.pause, m21.expressions.Fermata):
+                pauseStr = ' with fermata'
+            else:
+                pauseStr = ' with pause (non-fermata)'
+
+        output: str = f'{barline.type}{pauseStr}'
+        if not isinstance(barline, m21.bar.Repeat):
+            return f'BL:{output}'
+
+        # add the Repeat fields (direction, times)
+        if barline.direction is not None:
+            output += f' direction={barline.direction}'
+        if barline.times is not None:
+            output += f' times={barline.times}'
+        return f'RPT:{output}'
+
+    @staticmethod
     def extra_to_string(extra: m21.base.Music21Object) -> str:
         # object classes that have text content in a single field
         if isinstance(extra, (m21.key.Key, m21.key.KeySignature)):
@@ -499,6 +520,8 @@ class M21Utils:
             return M21Utils.timesig_to_string(extra)
         if isinstance(extra, m21.tempo.TempoIndication):
             return M21Utils.tempo_to_string(extra)
+        if isinstance(extra, m21.bar.Barline):
+            return M21Utils.barline_to_string(extra)
 
         print(f'Unexpected extra: {extra.classes[0]}', file=sys.stderr)
         return ''

--- a/musicdiff/m21utils.py
+++ b/musicdiff/m21utils.py
@@ -394,9 +394,19 @@ class M21Utils:
         # substreams/Voices), skipping any Streams, GeneralNotes (which are returned from
         # get_notes/get_notes_and_gracenotes), and Barlines.  We're looking for things
         # like Clefs, TextExpressions, and Dynamics...
-        output: List[m21.base.Music21Object] = list(measure.recurse().getElementsNotOfClass((m21.note.GeneralNote,
-                                                        m21.stream.Stream,
-                                                        m21.layout.LayoutBase )))
+        output: List[m21.base.Music21Object] = []
+
+        initialList: List[m21.base.Music21Object] = list(
+            measure.recurse().getElementsNotOfClass(
+                (m21.note.GeneralNote,
+                 m21.stream.Stream,
+                 m21.layout.LayoutBase) ) )
+
+        # loop over the initialList, filtering out (and complaining about) things we
+        # don't recognize.
+        for el in initialList:
+            if M21Utils.extra_to_string(el) != '':
+                output.append(el)
 
         # we must add any Crescendo/Diminuendo spanners that start on GeneralNotes in this measure
         for gn in measure.recurse().getElementsByClass(m21.note.GeneralNote):


### PR DESCRIPTION
Now musicdiff will tell us if a barline style (e.g. heavy-light vs double) or repeat mark is different.