### PR TITLE
Support for comparison of lyrics

### DIFF
--- a/musicdiff/annotation.py
+++ b/musicdiff/annotation.py
@@ -15,7 +15,7 @@
 __docformat__ = "google"
 
 from fractions import Fraction
-from typing import Optional
+from typing import Optional, List
 
 import music21 as m21
 
@@ -92,6 +92,18 @@ class AnnNote:
         if self.expressions:
             self.expressions.sort()
 
+        # lyrics
+        self.lyrics: List[str] = []
+        for lyric in general_note.lyrics:
+            lyricStr: str = lyric.rawText
+            if lyric.number is not None:
+                lyricStr += f" num={lyric.number}"
+            if lyric.identifier is not None:
+                lyricStr += f" id={lyric.identifier}"
+            if M21Utils.has_style(lyric):
+                lyricStr += f"style={M21Utils.obj_to_styledict(lyric, detail)}"
+            self.lyrics.append(lyricStr)
+
         # precomputed representations for faster comparison
         self.precomputed_str = self.__str__()
 
@@ -116,13 +128,15 @@ class AnnNote:
         size += len(self.articulations)
         # add for the expressions
         size += len(self.expressions)
+        # add for the lyrics
+        size += len(self.lyrics)
         return size
 
     def __repr__(self):
         # does consider the MEI id!
         return (f"{self.pitches},{self.note_head},{self.dots},{self.beamings}," +
-                f"{self.tuplets},{self.general_note},{self.articulations},{self.expressions}" +
-                f"{self.styledict}")
+                f"{self.tuplets},{self.general_note},{self.articulations},{self.expressions}," +
+                f"{self.lyrics},{self.styledict}")
 
     def __str__(self):
         """
@@ -172,6 +186,9 @@ class AnnNote:
         if len(self.expressions) > 0:  # add for articulations
             for e in self.expressions:
                 string += e
+        if len(self.lyrics) > 0:  # add for lyrics
+            for lyric in self.lyrics:
+                string += lyric
 
         if self.noteshape != 'normal':
             string += f"noteshape={self.noteshape}"

--- a/musicdiff/annotation.py
+++ b/musicdiff/annotation.py
@@ -95,13 +95,18 @@ class AnnNote:
         # lyrics
         self.lyrics: List[str] = []
         for lyric in general_note.lyrics:
-            lyricStr: str = lyric.rawText
+            lyricStr: str = ""
             if lyric.number is not None:
-                lyricStr += f" num={lyric.number}"
-            if lyric.identifier is not None:
-                lyricStr += f" id={lyric.identifier}"
+                lyricStr += f"number={lyric.number}"
+            if lyric._identifier is not None:
+                lyricStr += f" identifier={lyric._identifier}"
+            if lyric.syllabic is not None:
+                lyricStr += f" syllabic={lyric.syllabic}"
+            if lyric.text is not None:
+                lyricStr += f" text={lyric.text}"
+            lyricStr += f" rawText={lyric.rawText}"
             if M21Utils.has_style(lyric):
-                lyricStr += f"style={M21Utils.obj_to_styledict(lyric, detail)}"
+                lyricStr += f" style={M21Utils.obj_to_styledict(lyric, detail)}"
             self.lyrics.append(lyricStr)
 
         # precomputed representations for faster comparison

--- a/musicdiff/comparison.py
+++ b/musicdiff/comparison.py
@@ -637,6 +637,18 @@ class Comparison:
             )
             op_list.extend(expr_op_list)
             cost += expr_cost
+        # add for the lyrics
+        if annNote1.lyrics != annNote2.lyrics:
+            lyr_op_list, lyr_cost = Comparison._generic_leveinsthein_diff(
+                annNote1.lyrics,
+                annNote2.lyrics,
+                annNote1,
+                annNote2,
+                "lyric",
+            )
+            op_list.extend(lyr_op_list)
+            cost += lyr_cost
+
         # add for noteshape
         if annNote1.noteshape != annNote2.noteshape:
             cost += 1

--- a/musicdiff/visualization.py
+++ b/musicdiff/visualization.py
@@ -896,6 +896,55 @@ class Visualization:
                 textExp.style.color = Visualization.CHANGED_COLOR
                 note2.activeSite.insert(note2.offset, textExp)
 
+            # lyrics
+            elif op[0] == "inslyric":
+                assert isinstance(op[1], AnnNote)
+                assert isinstance(op[2], AnnNote)
+                # color the modified note in both scores using Visualization.INSERTED_COLOR
+                note1 = score1.recurse().getElementById(op[1].general_note)
+                note1.style.color = Visualization.INSERTED_COLOR
+                textExp = m21.expressions.TextExpression("inserted lyric")
+                textExp.style.color = Visualization.INSERTED_COLOR
+                note1.activeSite.insert(note1.offset, textExp)
+
+                note2 = score2.recurse().getElementById(op[2].general_note)
+                note2.style.color = Visualization.INSERTED_COLOR
+                textExp = m21.expressions.TextExpression("inserted lyric")
+                textExp.style.color = Visualization.INSERTED_COLOR
+                note2.activeSite.insert(note2.offset, textExp)
+
+            elif op[0] == "dellyric":
+                assert isinstance(op[1], AnnNote)
+                assert isinstance(op[2], AnnNote)
+                # color the modified note in both scores using Visualization.DELETED_COLOR
+                note1 = score1.recurse().getElementById(op[1].general_note)
+                note1.style.color = Visualization.DELETED_COLOR
+                textExp = m21.expressions.TextExpression("deleted lyric")
+                textExp.style.color = Visualization.DELETED_COLOR
+                note1.activeSite.insert(note1.offset, textExp)
+
+                note2 = score2.recurse().getElementById(op[2].general_note)
+                note2.style.color = Visualization.DELETED_COLOR
+                textExp = m21.expressions.TextExpression("deleted lyric")
+                textExp.style.color = Visualization.DELETED_COLOR
+                note2.activeSite.insert(note2.offset, textExp)
+
+            elif op[0] == "editlyric":
+                assert isinstance(op[1], AnnNote)
+                assert isinstance(op[2], AnnNote)
+                # color the modified note (in both scores) using Visualization.CHANGED_COLOR
+                note1 = score1.recurse().getElementById(op[1].general_note)
+                note1.style.color = Visualization.CHANGED_COLOR
+                textExp = m21.expressions.TextExpression("changed lyric")
+                textExp.style.color = Visualization.CHANGED_COLOR
+                note1.activeSite.insert(note1.offset, textExp)
+
+                note2 = score2.recurse().getElementById(op[2].general_note)
+                note2.style.color = Visualization.CHANGED_COLOR
+                textExp = m21.expressions.TextExpression("changed lyric")
+                textExp.style.color = Visualization.CHANGED_COLOR
+                note2.activeSite.insert(note2.offset, textExp)
+
             else:
                 print(f"Annotation type {op[0]} not yet supported for visualization", file=sys.stderr)
 


### PR DESCRIPTION
Lyrics are attached to GeneralNotes as an array, just like articulations and expressions.  I patterned my support after those, although the array of strings isn't just an array of articulation/expression names, it contains a fair bit of stringified detail about the lyric (including style, if the client wants that level of detail).