### PR TITLE
Keep extra name when extra.kind is not in Visualization._HEADER_NAME_…

### DIFF
--- a/musicdiff/visualization.py
+++ b/musicdiff/visualization.py
@@ -3172,8 +3172,9 @@ class Visualization:
             if op[0].startswith('extra'):
                 extra: AnnExtra | None = op[1] or op[2]
                 if extra is not None and extra.kind:
-                    name = re.sub('extra', extra.kind, op[0])
-                    name = Visualization._HEADER_NAME_OF_EDIT_NAME[name]
+                    _name = re.sub('extra', extra.kind, op[0])
+                    if _name in Visualization._HEADER_NAME_OF_EDIT_NAME:
+                        name = Visualization._HEADER_NAME_OF_EDIT_NAME[_name]
             omr_ed: int = op[3]
             if name not in edit_distances_dict:
                 edit_distances_dict[name] = omr_ed


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the `musicdiff.visualization.get_edit_distances_dict` function where the name with a prefix `extra` is replaced with a more specific type (`op[1]` or `op[2]`). However, some of these types are not present in the `Visualization._HEADER_NAME_OF_EDIT_NAME` dictionary, leading to a runtime error.

This PR resolves the issue by falling back to the original `extra...` name when the specific type is not found in the dictionary.