### PR TITLE
Memoize diff results by element identity, stop deep-copying on hits

### DIFF
--- a/musicdiff/comparison.py
+++ b/musicdiff/comparison.py
@@ -77,106 +77,36 @@ class DiffOperation:
 
         return (m21_obj1, m21_obj2)
 
-# memoizers to speed up the recursive computation
-def _memoize_notes_set_distance(func):
-    def memoizer(original, compare_to):
-        key = repr(original) + repr(compare_to)
-        if key not in Comparison._memoizer_mem:
-            Comparison._memoizer_mem[key] = func(original, compare_to)
-        return copy.deepcopy(Comparison._memoizer_mem[key])
+# memoizer to speed up the recursive computation
+def _memoize_diff(func):
+    fname = func.__name__
 
-    return memoizer
-
-def _memoize_extras_set_distance(func):
-    def memoizer(original, compare_to):
-        key = repr(original) + repr(compare_to)
-        if key not in Comparison._memoizer_mem:
-            Comparison._memoizer_mem[key] = func(original, compare_to)
-        return copy.deepcopy(Comparison._memoizer_mem[key])
-
-    return memoizer
-
-def _memoize_staff_groups_set_distance(func):
-    def memoizer(original, compare_to):
-        key = repr(original) + repr(compare_to)
-        if key not in Comparison._memoizer_mem:
-            Comparison._memoizer_mem[key] = func(original, compare_to)
-        return copy.deepcopy(Comparison._memoizer_mem[key])
-
-    return memoizer
-
-def _memoize_metadata_items_set_distance(func):
-    def memoizer(original, compare_to):
-        key = repr(original) + repr(compare_to)
-        if key not in Comparison._memoizer_mem:
-            Comparison._memoizer_mem[key] = func(original, compare_to)
-        return copy.deepcopy(Comparison._memoizer_mem[key])
-
-    return memoizer
-
-def _memoize_inside_bars_diff_lin(func):
-    def memoizer(original, compare_to):
-        key = repr(original) + repr(compare_to)
-        if key not in Comparison._memoizer_mem:
-            Comparison._memoizer_mem[key] = func(original, compare_to)
-        return copy.deepcopy(Comparison._memoizer_mem[key])
-
-    return memoizer
-
-def _memoize_lyrics_diff_lin(func):
-    def memoizer(original, compare_to):
-        key = repr(original) + repr(compare_to)
-        if key not in Comparison._memoizer_mem:
-            Comparison._memoizer_mem[key] = func(original, compare_to)
-        return copy.deepcopy(Comparison._memoizer_mem[key])
-
-    return memoizer
-
-def _memoize_block_diff_lin(func):
-    def memoizer(original, compare_to):
-        key = repr(original) + repr(compare_to)
-        if key not in Comparison._memoizer_mem:
-            Comparison._memoizer_mem[key] = func(original, compare_to)
-        return copy.deepcopy(Comparison._memoizer_mem[key])
-
-    return memoizer
-
-def _memoize_pitches_lev_diff(func):
-    def memoizer(original, compare_to, noteNode1, noteNode2, ids):
+    def memoizer(original, compare_to, *rest):
         key = (
-            repr(original)
-            + repr(compare_to)
-            + repr(noteNode1)
-            + repr(noteNode2)
-            + repr(ids)
+            fname,
+            tuple(id(o) for o in original),
+            tuple(id(c) for c in compare_to),
+            tuple(r if isinstance(r, (str, int, tuple)) else id(r) for r in rest),
         )
-        if key not in Comparison._memoizer_mem:
-            Comparison._memoizer_mem[key] = func(original, compare_to, noteNode1, noteNode2, ids)
-        return copy.deepcopy(Comparison._memoizer_mem[key])
+        cached = Comparison._memoizer_mem.get(key)
+        if cached is None:
+            cached = func(original, compare_to, *rest)
+            Comparison._memoizer_mem[key] = cached
+        op_list, cost = cached
+        return list(op_list), cost
 
     return memoizer
 
-def _memoize_beamtuplet_lev_diff(func):
-    def memoizer(original, compare_to, noteNode1, noteNode2, which):
-        key = (
-            repr(original) + repr(compare_to) + repr(noteNode1) + repr(noteNode2) + which
-        )
-        if key not in Comparison._memoizer_mem:
-            Comparison._memoizer_mem[key] = func(original, compare_to, noteNode1, noteNode2, which)
-        return copy.deepcopy(Comparison._memoizer_mem[key])
-
-    return memoizer
-
-def _memoize_generic_lev_diff(func):
-    def memoizer(original, compare_to, noteNode1, noteNode2, which):
-        key = (
-            repr(original) + repr(compare_to) + repr(noteNode1) + repr(noteNode2) + which
-        )
-        if key not in Comparison._memoizer_mem:
-            Comparison._memoizer_mem[key] = func(original, compare_to, noteNode1, noteNode2, which)
-        return copy.deepcopy(Comparison._memoizer_mem[key])
-
-    return memoizer
+_memoize_notes_set_distance = _memoize_diff
+_memoize_extras_set_distance = _memoize_diff
+_memoize_staff_groups_set_distance = _memoize_diff
+_memoize_metadata_items_set_distance = _memoize_diff
+_memoize_inside_bars_diff_lin = _memoize_diff
+_memoize_lyrics_diff_lin = _memoize_diff
+_memoize_block_diff_lin = _memoize_diff
+_memoize_pitches_lev_diff = _memoize_diff
+_memoize_beamtuplet_lev_diff = _memoize_diff
+_memoize_generic_lev_diff = _memoize_diff
 
 class Comparison:
     _memoizer_mem: dict = {}


### PR DESCRIPTION
The _memoize_* decorators keyed the cache by repr() of the entire compared suffixes — rebuilt on every recursive call — and returned copy.deepcopy of the cached (op_list, cost) on every hit, cloning the annotation objects referenced by the operations. Comparing large scores took tens of minutes (a ~13k-note score: ~30 min; seconds once fixed).

Replace the 13 identical decorators with a single one that keys by the id() of the sequence elements (safe: the annotation objects live as long as the compared AnnScores and the cache is cleared at the start of every comparison; this also stops two equal-looking but distinct objects from sharing an entry and returning operations that reference the wrong one) and returns a shallow copy of the cached op_list (callers append to the returned list but never mutate its elements). Results are unchanged.